### PR TITLE
Normalize Quoted-Printable line endings for text content

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -9,6 +9,7 @@ Breaking changes:
 
 Compatibility:
 * Handle a wide variety of non-RFC Message-ID formats. (peterkovacs)
+* Normalize Quoted-Printable line endings for text content. (jeremy)
 * Gracefully parse invalid dates in Date and Received headers. (okkez)
 * Converting to multipart moves Content-* headers to the new part. (kirikak2)
 * Multipart Content-Type no longer includes a needless charset param. (kirikak2)

--- a/lib/mail/encodings/quoted_printable.rb
+++ b/lib/mail/encodings/quoted_printable.rb
@@ -16,11 +16,11 @@ module Mail
       # Decode the string from Quoted-Printable. Cope with hard line breaks
       # that were incorrectly encoded as hex instead of literal CRLF.
       def self.decode(str)
-        str.gsub(/(?:=0D=0A|=0D|=0A)\r\n/, "\r\n").unpack("M*").first
+        ::Mail::Utilities.to_lf ::Mail::Utilities.to_crlf(str).gsub(/(?:=0D=0A|=0D|=0A)\r\n/, "\r\n").unpack("M*").first
       end
 
       def self.encode(str)
-        [str].pack("M")
+        ::Mail::Utilities.to_crlf [::Mail::Utilities.to_lf(str)].pack("M")
       end
 
       def self.cost(str)

--- a/spec/mail/encodings/quoted_printable_spec.rb
+++ b/spec/mail/encodings/quoted_printable_spec.rb
@@ -4,49 +4,59 @@ require 'spec_helper'
 describe Mail::Encodings::QuotedPrintable do
   
   it "should encode quoted printable from text" do
-    result = "This is\na test=\n"
+    result = "This is\r\na test=\r\n"
     expect(Mail::Encodings::QuotedPrintable.encode("This is\na test")).to eq result
   end
 
   it "should encode quoted printable from crlf text" do
-    result = "This is=0D\na test=\n"
+    result = "This is\r\na test=\r\n"
     expect(Mail::Encodings::QuotedPrintable.encode("This is\r\na test")).to eq result
   end
 
   it "should encode quoted printable from cr text" do
-    result = "This is=0Da test=\n"
+    result = "This is\r\na test=\r\n"
     expect(Mail::Encodings::QuotedPrintable.encode("This is\ra test")).to eq result
   end
-  
+
+  it "should bypass line ending conversion for binary encoding" do
+    text = "test \r \xF0\x9F\x8D\xBF"
+    text = text.dup.force_encoding(Encoding::BINARY) if text.respond_to?(:force_encoding)
+    expect(Mail::Encodings::QuotedPrintable.encode(text)).to eq "test =0D =F0=9F=8D=BF=\r\n"
+  end
+
   it "should decode quoted printable" do
-    result = "This is\r\na test"
+    result = "This is\na test"
     expect(Mail::Encodings::QuotedPrintable.decode("This is\r\na test")).to eq result
   end
-  
+
   it "should encode quoted printable from binary" do
-    result = "=00=00=00=00=\n"
-    expect(Mail::Encodings::QuotedPrintable.encode("\000\000\000\000")).to eq result
+    text = "\000\000\r\xF0\x9F\x98\x8A\n\000\000"
+    text = text.dup.force_encoding(Encoding::BINARY) if text.respond_to?(:force_encoding)
+    expect(Mail::Encodings::QuotedPrintable.encode(text)).to eq "=00=00=0D=F0=9F=98=8A\r\n=00=00=\r\n"
   end
-  
+
   it "should decode quoted printable text" do
-    result = "\000\000\000\000"
-    expect(Mail::Encodings::QuotedPrintable.decode("=00=00=00=00")).to eq result
+    result = "\000\000\n\000\000"
+    expect(Mail::Encodings::QuotedPrintable.decode("=00=00=0D=0A=00=00")).to eq result
+  end
+
+  it "should bypass line ending conversion for binary decoding" do
+    result = "test \r \xF0\x9F\x8D\xBF"
+    result = result.dup.force_encoding(Encoding::BINARY) if result.respond_to?(:force_encoding)
+    expect(Mail::Encodings::QuotedPrintable.decode("test =0D =F0=9F=8D=BF=\n")).to eq result
   end
 
   [["\r", "=0D"], ["\n", "=0A"], ["\r\n", "=0D=0A"]].each do |crlf, linebreak|
-    expected = "first line wraps\r\n\r\nsecond paragraph"
+    expected = "first line wraps\n\nsecond paragraph"
+
     it "should cope with inappropriate #{linebreak} line break encoding" do
       body = "first line=\r\n wraps#{linebreak}\r\n#{linebreak}\r\nsecond paragraph=\r\n"
       expect(Mail::Encodings::QuotedPrintable.decode(body)).to eq expected
     end
-  end
 
-  [["\r", "=0D"], ["\n", "=0A"], ["\r\n", "=0D=0A"]].each do |crlf, linebreak|
-    expected = "first line wraps#{crlf}#{crlf}second paragraph"
     it "should allow encoded #{linebreak} line breaks with soft line feeds" do
       body = "first line=\r\n wraps#{linebreak}=\r\n#{linebreak}=\r\nsecond paragraph=\r\n"
       expect(Mail::Encodings::QuotedPrintable.decode(body)).to eq expected
     end
   end
-  
 end

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1554,7 +1554,7 @@ describe Mail::Message do
           body "The=3Dbody"
         end
         expect(mail.body.decoded).to eq "The=body"
-        expect(mail.body.encoded).to eq "The=3Dbody=\n"
+        expect(mail.body.encoded).to eq "The=3Dbody=\r\n"
       end
 
       it "should change a body on decode if given an encoding type to decode" do


### PR DESCRIPTION
If a string has binary content, leave \r\n characters as-is.